### PR TITLE
refactor: use Decimal for financial calculations

### DIFF
--- a/.agents/skills/python-type-checking/SKILL.md
+++ b/.agents/skills/python-type-checking/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: python-type-checking
+description: When performing python type checking, use the pyright terminal command
+---
+
+
+1. type check Python files using `pipenv run pyright`
+2. if no type errors, you are done
+3. if type errors, attempt to fix them and return to #1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,6 @@
 - use conventional commit messages
 - format code with black formatter in pipenv dependencies after code changes
-- run tests with pipenv run, and install dependencies using pipenv
+- before committing, run tests and ensure there are no type checking errors
+- when running tests, use pipenv run pytest
+- when installing dependencies, use pipenv
 - keep things simple

--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,7 @@ six = "==1.16.0"
 [dev-packages]
 black = "*"
 pytest = "*"
+pyright = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b9629c1c2549dd12b6044533a3d1c5f44183b2c0ccc1cf9b985f47d16d51d1f8"
+            "sha256": "c2a2dde4eb62d8bb9cda819b8443b9bba47e7a83cda4c03248a6a3e5f4dcd6a2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -447,45 +447,45 @@
     "develop": {
         "black": {
             "hashes": [
-                "sha256:03102aa97c279e5f62e1e1ab828cfe8aa72c3af4cf86f9448e5537b2519cbfea",
-                "sha256:081df4dc908702e2becd66d714f125a954cbf1c6dbe2ad83a6be313368c7c2db",
-                "sha256:0a789a41b386f0f83711785f182f2977138ba9cc1f41ad0f6fbc8faac4d2639e",
-                "sha256:1f80998e73fcfc67fc1d222060cf34ab213f1ae7e131b5c8199d93405890c13a",
-                "sha256:209fabb250681900502b3b6a03e31d8cac606c9ef9629fd0fbd5d33235647c00",
-                "sha256:2178a70e7c45fb85999b687d8326abceef1e7227463d5d7e07ef125c9fbb9c5c",
-                "sha256:241f25bf59f5ca17f5121031e310e089b84cd22bb4eca47360099ea825544f17",
-                "sha256:3968ce82ca0bd4914769518490d91a9b0ef2ff2fc68e2122d22b5915a0342eaa",
-                "sha256:402454bfdd7a940be00455e87309438a24b328b7ba7d80b7207e8a87b32ffc29",
-                "sha256:4863b2a2c382661a018bf2213f2b957fa34511df131259ffaa8d54859620ac31",
-                "sha256:490b623006a75c0ea59c1ecf91cc76ecb9d66df1482c3a53f4f7de95a7c85e10",
-                "sha256:5cbe4cc4037ffca34cdb0a6a9a046f104b262d0bd63c30fd4a88c7adc2049b1d",
-                "sha256:6f53deb3d1108a523212da5c79e5c0cd76abcc548948f2d8415e62929c81a569",
-                "sha256:828db2292848cf427592fcd162f02d770849d20ea4bdda2806e9494b3a15d481",
-                "sha256:862945b2a08193cdff9f632f51bdadbb11e6852da1d31c306a3508449dc81b84",
-                "sha256:8ea767bae9c4f331ea9ad2e08895c951e600dffd550a42624d5210a908720b39",
-                "sha256:990ee0e1d96dd8ca623f19dd3f339c138bdc02f74e4fea01cc64aee38944ea2b",
-                "sha256:a62f9d069ac27de20c6fa3dbf60d7c951141c4025bb9755274802d05b1aa418b",
-                "sha256:b92983a6674c133ca61d6b4fea17f76cbbaac582ea583002792ee1094dbece49",
-                "sha256:c2b64ce9841e8b8254c3d702ebccdaf5c520607df8aa4176f5732b7f9af1e6f6",
-                "sha256:c5b08371561dae9c90391fe7f2138fe7fa495437d3bb134eb865839036e65784",
-                "sha256:cf015b38829ca32a699312fdcfb8c15bd0b156192f5400bd0b559c6bfef25236",
-                "sha256:d658f4ee6167797b08be07ee4bbf6045753ddabfc676c3cb0eec23752ca83eff",
-                "sha256:dbb6fc70f8bd9821981fd47efb68a5be0eee9055f400eb3bf2dbebf49f9ec4fe",
-                "sha256:ea8a0c4505486c132c6640e4e108d25f41360a06d844db5a76477c3dbae1b616",
-                "sha256:f3ad14d7c24c40eafecf4fb212d9c01e7c7b2ab05c8646b351c93728f499c555",
-                "sha256:f69837f7e26d67b1d1e9d0ed49231a14a0469f266e44cd142873e0552f325395"
+                "sha256:0e48b87e03bf109288e55cfceadcfa15ff5470aca2851a851950ed2926f450d7",
+                "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418",
+                "sha256:1ef92b76f7733f282fd096ea406200b5a286c42947412b0eaff3a74e3616cefe",
+                "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0",
+                "sha256:22f2cd76d069cc54c71f10360744ba8983fbb616903b4304a85b734915c8e1b4",
+                "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3",
+                "sha256:30d3c14661f2792e9142cce3eeeb1cbc175b3eb5f733be0c8eeb99651e52b0c3",
+                "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3",
+                "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217",
+                "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8",
+                "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2",
+                "sha256:5119fa92ae61f786e8c3662fd60aece1d0a2dd5cca5d0c79417a95e7a4272a59",
+                "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50",
+                "sha256:58b4bd92cf88aacf83d88479c8f9caee044b1ec55f2451a337354a7ea2590a22",
+                "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52",
+                "sha256:87ed5c6f450580a2f6790bc7cbfb016dfc73bc750249762268a3695361315eef",
+                "sha256:89c93167a74d3a75dfaa38a5c7cca015537d5820dd7f17d63267d674a61cae90",
+                "sha256:96ae2c733b2aabdd9986e2c5df628ff3473676cd1c5faded1ff496cf6d74083c",
+                "sha256:9942db8888e06943c5dde66ca0037dcff82a2a4ec1ad0ada9e0d2ee9d9823893",
+                "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d",
+                "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264",
+                "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73",
+                "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a",
+                "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168",
+                "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18",
+                "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294",
+                "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==26.5.0"
+            "version": "==26.5.1"
         },
         "click": {
             "hashes": [
-                "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81",
-                "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973"
+                "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2",
+                "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.4.0"
+            "version": "==8.4.1"
         },
         "exceptiongroup": {
             "hashes": [
@@ -510,6 +510,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==1.1.0"
+        },
+        "nodeenv": {
+            "hashes": [
+                "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827",
+                "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
+            "version": "==1.10.0"
         },
         "packaging": {
             "hashes": [
@@ -551,6 +559,15 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==2.20.0"
+        },
+        "pyright": {
+            "hashes": [
+                "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93",
+                "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==1.1.409"
         },
         "pytest": {
             "hashes": [

--- a/calculate/retirement.py
+++ b/calculate/retirement.py
@@ -1,3 +1,4 @@
+from typing import Union
 from decimal import Decimal, ROUND_HALF_UP
 from calculate.tax import calculate_annual_income_tax
 from utils.parameters import Person, Account, to_decimal
@@ -20,7 +21,9 @@ def simulate_account(account: Account) -> tuple[list[int], list[Decimal]]:
     return graph_labels, graph_savings_values
 
 
-def _adjust_for_inflation(todays_dollars: Decimal, months: int) -> Decimal:
+def _adjust_for_inflation(
+    todays_dollars: Union[Decimal, float, int], months: int
+) -> Decimal:
     todays_dollars_dec = to_decimal(todays_dollars)
     inflation_rate_dec = to_decimal(GlobalParameters.inflation_rate)
     inflation_multiplier = Decimal("1") + inflation_rate_dec
@@ -28,10 +31,11 @@ def _adjust_for_inflation(todays_dollars: Decimal, months: int) -> Decimal:
     return todays_dollars_dec * (inflation_per_month**months)
 
 
-def _calculate_pre_tax_income(post_tax_income: Decimal) -> Decimal:
+def _calculate_pre_tax_income(post_tax_income: Union[Decimal, float, int]) -> Decimal:
     # binary search
-    left = post_tax_income
-    right = post_tax_income * Decimal("5")
+    post_tax_income_dec = to_decimal(post_tax_income)
+    left = post_tax_income_dec
+    right = post_tax_income_dec * Decimal("5")
     pre_tax_income = right
 
     # stop once error is smaller than cent
@@ -40,7 +44,7 @@ def _calculate_pre_tax_income(post_tax_income: Decimal) -> Decimal:
         if (
             pre_tax_income
             - calculate_annual_income_tax(Person(pre_tax_income=pre_tax_income))
-            > post_tax_income
+            > post_tax_income_dec
         ):
             right = pre_tax_income
         else:

--- a/calculate/retirement.py
+++ b/calculate/retirement.py
@@ -1,11 +1,11 @@
-import math
+from decimal import Decimal, ROUND_HALF_UP
 from calculate.tax import calculate_annual_income_tax
-from utils.parameters import Person, Account
+from utils.parameters import Person, Account, to_decimal
 from utils.enums import Frequency, MonthlyCompoundType, AccountType
 from utils.globals import GlobalParameters
 
 
-def simulate_account(account: Account):
+def simulate_account(account: Account) -> tuple[list[int], list[Decimal]]:
     graph_labels = []
     graph_savings_values = []
     current_savings = account.initial_savings
@@ -20,21 +20,23 @@ def simulate_account(account: Account):
     return graph_labels, graph_savings_values
 
 
-def _adjust_for_inflation(todays_dollars: float, months: int) -> float:
-    inflation_multiplier = 1 + GlobalParameters.inflation_rate
-    inflation_per_month = math.pow(inflation_multiplier, 1 / 12)
-    return todays_dollars * math.pow(inflation_per_month, months)
+def _adjust_for_inflation(todays_dollars: Decimal, months: int) -> Decimal:
+    todays_dollars_dec = to_decimal(todays_dollars)
+    inflation_rate_dec = to_decimal(GlobalParameters.inflation_rate)
+    inflation_multiplier = Decimal("1") + inflation_rate_dec
+    inflation_per_month = inflation_multiplier ** (Decimal("1") / Decimal("12"))
+    return todays_dollars_dec * (inflation_per_month**months)
 
 
-def _calculate_pre_tax_income(post_tax_income: float):
+def _calculate_pre_tax_income(post_tax_income: Decimal) -> Decimal:
     # binary search
     left = post_tax_income
-    right = post_tax_income * 5
+    right = post_tax_income * Decimal("5")
     pre_tax_income = right
 
     # stop once error is smaller than cent
-    while abs(right - left) > 0.01:
-        pre_tax_income = left + (right - left) / 2
+    while abs(right - left) > Decimal("0.01"):
+        pre_tax_income = left + (right - left) / Decimal("2")
         if (
             pre_tax_income
             - calculate_annual_income_tax(Person(pre_tax_income=pre_tax_income))
@@ -44,41 +46,46 @@ def _calculate_pre_tax_income(post_tax_income: float):
         else:
             left = pre_tax_income
 
-    return round(pre_tax_income, 2)
+    return pre_tax_income.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
 def _simulate_accumulation(
     account: Account,
-    current_savings: float,
+    current_savings: Decimal,
     graph_labels: list[int],
-    graph_savings_values: list[float],
-) -> float:
+    graph_savings_values: list[Decimal],
+) -> Decimal:
     for year in range(account.owner.retirement_age - account.owner.current_age):
         # compounding yearly
         if account.compound_frequency == Frequency.ANNUALLY:
-            current_savings *= 1 + account.annual_investment_return
+            current_savings *= Decimal("1") + account.annual_investment_return
 
         for month in range(12):
             # compounding monthly
             if account.compound_frequency == Frequency.MONTHLY:
                 if account.compound_type == MonthlyCompoundType.DIVIDE:
-                    current_savings *= 1 + account.annual_investment_return / 12
+                    current_savings *= Decimal(
+                        "1"
+                    ) + account.annual_investment_return / Decimal("12")
                 elif account.compound_type == MonthlyCompoundType.ROOT:
-                    current_savings *= math.pow(
-                        1 + account.annual_investment_return, 1 / 12
-                    )
+                    current_savings *= (
+                        Decimal("1") + account.annual_investment_return
+                    ) ** (Decimal("1") / Decimal("12"))
 
             # monthly addition to investment account
             if account.regular_investment_frequency == Frequency.MONTHLY:
-                current_savings += account.regular_investment_dollar * math.pow(
-                    math.pow(1 + account.annual_investment_increase, 1 / 12),
-                    year * 12 + month,
+                current_savings += account.regular_investment_dollar * (
+                    (
+                        (Decimal("1") + account.annual_investment_increase)
+                        ** (Decimal("1") / Decimal("12"))
+                    )
+                    ** (year * 12 + month)
                 )
 
         # yearly addition to investment account
         if account.regular_investment_frequency == Frequency.ANNUALLY:
-            current_savings += account.regular_investment_dollar * math.pow(
-                1 + account.annual_investment_increase, year
+            current_savings += account.regular_investment_dollar * (
+                (Decimal("1") + account.annual_investment_increase) ** year
             )
 
         graph_labels.append(account.owner.current_age + year)
@@ -89,10 +96,10 @@ def _simulate_accumulation(
 
 def _simulate_retirement(
     account: Account,
-    current_savings: float,
+    current_savings: Decimal,
     graph_labels: list[int],
-    graph_savings_values: list[float],
-):
+    graph_savings_values: list[Decimal],
+) -> None:
     # retirement phase (no social security)
     retirement_months = 0
     annual_retirement_withdrawal = account.annual_retirement_post_tax_expense
@@ -107,7 +114,7 @@ def _simulate_retirement(
         )
 
     while (
-        current_savings >= annual_retirement_withdrawal / 12
+        current_savings >= annual_retirement_withdrawal / Decimal("12")
         and account.owner.retirement_age + retirement_months // 12
         < account.owner.lifespan
     ):
@@ -117,16 +124,18 @@ def _simulate_retirement(
             account.owner.retirement_age - account.owner.current_age
         ) * 12 + retirement_months
         current_savings -= _adjust_for_inflation(
-            annual_retirement_withdrawal / 12, months_since_today
+            annual_retirement_withdrawal / Decimal("12"), months_since_today
         )
 
         if account.compound_frequency == Frequency.MONTHLY:
-            current_savings *= math.pow(1 + account.annual_retirement_return, 1 / 12)
+            current_savings *= (Decimal("1") + account.annual_retirement_return) ** (
+                Decimal("1") / Decimal("12")
+            )
         elif (
             account.compound_frequency == Frequency.ANNUALLY
             and retirement_months % 12 == 0
         ):
-            current_savings *= 1 + account.annual_retirement_return
+            current_savings *= Decimal("1") + account.annual_retirement_return
 
         # add to remaining months
         retirement_months += 1
@@ -135,6 +144,6 @@ def _simulate_retirement(
             graph_labels.append(account.owner.retirement_age + retirement_months // 12)
             graph_savings_values.append(current_savings)
 
-    if current_savings < 0:
+    if current_savings < Decimal("0"):
         graph_labels.append(account.owner.retirement_age + retirement_months // 12 + 1)
-        graph_savings_values.append(0)
+        graph_savings_values.append(Decimal("0"))

--- a/calculate/tax.py
+++ b/calculate/tax.py
@@ -1,11 +1,11 @@
-import math
+from decimal import Decimal
 from utils.enums import Filing, State
 from utils.parameters import Person
 from utils.globals import GlobalParameters
 
 
 # federal income, state income, social security, medicare
-def calculate_annual_income_tax(user: Person) -> float:
+def calculate_annual_income_tax(user: Person) -> Decimal:
     return (
         calculate_annual_federal_income_tax(user)
         + calculate_annual_social_security_tax(user)
@@ -14,7 +14,7 @@ def calculate_annual_income_tax(user: Person) -> float:
     )
 
 
-def calculate_annual_federal_income_tax(user: Person) -> float:
+def calculate_annual_federal_income_tax(user: Person) -> Decimal:
     return _calculate_annual_income_tax(
         user,
         tax_brackets=(
@@ -30,25 +30,25 @@ def calculate_annual_federal_income_tax(user: Person) -> float:
     )
 
 
-def calculate_annual_state_income_tax(user: Person) -> float:
+def calculate_annual_state_income_tax(user: Person) -> Decimal:
     tax_deduction = (
         GlobalParameters.state_standard_tax_deduction
         if user.filing == Filing.INDIVIDUAL
         else GlobalParameters.state_joint_tax_deduction
     )
-    additional_state_tax: float = 0.0
+    additional_state_tax = Decimal("0")
 
-    if user.state_of_residence == State.TEXAS or user.state_of_residence == None:
-        return 0.0
+    if user.state_of_residence == State.TEXAS or user.state_of_residence is None:
+        return Decimal("0")
 
     elif user.state_of_residence == State.CALIFORNIA:
         # SDI tax applies to 401(k) contributions
         # #?not sure if this applies to HSA contributions, although insignificant
-        SDI_tax = 0.011 * (user.pre_tax_income - tax_deduction)
+        SDI_tax = Decimal("0.011") * (user.pre_tax_income - tax_deduction)
         MHS_tax = (
-            0.01 * (user.get_reduced_income() - tax_deduction)
-            if user.get_reduced_income() > 1_000_000
-            else 0.0
+            Decimal("0.01") * (user.get_reduced_income() - tax_deduction)
+            if user.get_reduced_income() > Decimal("1000000")
+            else Decimal("0")
         )  # mental health services tax TODO need to change this to 2million for joint filers
         additional_state_tax += SDI_tax + MHS_tax
 
@@ -66,15 +66,17 @@ def calculate_annual_state_income_tax(user: Person) -> float:
 
 
 def _calculate_annual_income_tax(
-    user: Person, tax_brackets: list[tuple[float, int]], tax_deduction: int
-) -> float:
+    user: Person, tax_brackets: list[tuple[Decimal, Decimal]], tax_deduction: Decimal
+) -> Decimal:
     taxable_income = user.get_reduced_income() - tax_deduction
 
-    taxes_owed: float = 0.0
+    taxes_owed = Decimal("0")
     for i in range(len(tax_brackets)):
         tax_percent, floor_value = tax_brackets[i]
         ceiling_value = (
-            tax_brackets[i + 1][1] - 1 if i + 1 < len(tax_brackets) else math.inf
+            tax_brackets[i + 1][1] - Decimal("1")
+            if i + 1 < len(tax_brackets)
+            else Decimal("Infinity")
         )
         if taxable_income > ceiling_value:
             taxes_owed += (ceiling_value - floor_value) * tax_percent
@@ -86,15 +88,15 @@ def _calculate_annual_income_tax(
     return taxes_owed
 
 
-def calculate_annual_social_security_tax(user: Person) -> float:
+def calculate_annual_social_security_tax(user: Person) -> Decimal:
     social_security_taxable_income = min(
         user.get_fica_taxable_income(), GlobalParameters.social_security_max_taxable
     )
     return social_security_taxable_income * GlobalParameters.social_security_tax_percent
 
 
-def calculate_annual_medicare_tax(user: Person) -> float:
-    taxes_owed: float = 0.0
+def calculate_annual_medicare_tax(user: Person) -> Decimal:
+    taxes_owed = Decimal("0")
     medicare_high_earner_salary = (
         GlobalParameters.medicare_high_earner_salary_individual
         if user.filing == Filing.INDIVIDUAL

--- a/main.py
+++ b/main.py
@@ -73,7 +73,7 @@ def generate_income_distribution_graph(user: Person, ax: Axes):
 
     # add account contributions
     for account_name, account in user.accounts.items():
-        retirement_contributions: Decimal
+        retirement_contributions = Decimal("0")
 
         if account.regular_investment_frequency == Frequency.MONTHLY:
             retirement_contributions = account.regular_investment_dollar * 12

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 import copy
@@ -23,11 +24,12 @@ logger = logging.getLogger(__name__)
 def generate_investment_growth_graph(user: Person, ax: Axes):
     # calculate and show retirement simulation
     total_savings_graph_labels = []
-    total_savings_graph_values = []
+    total_savings_graph_values: list[Decimal] = []
 
     for account_name, account in user.accounts.items():
         graph_labels, graph_savings_values = simulate_account(account)
-        ax.plot(graph_labels, graph_savings_values, label=account_name)
+        float_savings_values = [float(v) for v in graph_savings_values]
+        ax.plot(graph_labels, float_savings_values, label=account_name)
 
         if len(graph_labels) > len(total_savings_graph_labels):
             total_savings_graph_labels = graph_labels
@@ -35,7 +37,7 @@ def generate_investment_growth_graph(user: Person, ax: Axes):
         # add to total
         for i in range(len(graph_savings_values)):
             if i >= len(total_savings_graph_values):
-                total_savings_graph_values.append(0)
+                total_savings_graph_values.append(Decimal("0"))
             total_savings_graph_values[i] += graph_savings_values[i]
 
     yearly_retirement_expense = sum(
@@ -45,9 +47,8 @@ def generate_investment_growth_graph(user: Person, ax: Axes):
         ]
     )
 
-    ax.plot(
-        total_savings_graph_labels, total_savings_graph_values, label="Total Savings"
-    )
+    float_total_savings = [float(v) for v in total_savings_graph_values]
+    ax.plot(total_savings_graph_labels, float_total_savings, label="Total Savings")
     ax.set_title("Retirement Savings", fontweight="semibold")
     ax.legend(loc="best")
     ax.set_xlabel(
@@ -60,19 +61,19 @@ def generate_income_distribution_graph(user: Person, ax: Axes):
     # calculate and show income pie chart
     # add taxes
     pie_labels = ["Federal Income tax", "Medicare Tax", "Social Security Tax"]
-    pie_sizes: list[float] = [
+    pie_sizes: list[Decimal] = [
         calculate_annual_federal_income_tax(user),
         calculate_annual_medicare_tax(user),
         calculate_annual_social_security_tax(user),
     ]
 
-    if calculate_annual_state_income_tax(user) > 0:
+    if calculate_annual_state_income_tax(user) > Decimal("0"):
         pie_labels.append("State Tax")
         pie_sizes.append(calculate_annual_state_income_tax(user))
 
     # add account contributions
     for account_name, account in user.accounts.items():
-        retirement_contributions: int
+        retirement_contributions: Decimal
 
         if account.regular_investment_frequency == Frequency.MONTHLY:
             retirement_contributions = account.regular_investment_dollar * 12
@@ -80,7 +81,7 @@ def generate_income_distribution_graph(user: Person, ax: Axes):
             retirement_contributions = account.regular_investment_dollar
 
         pie_labels.append(account_name + " contribution")
-        pie_sizes.append(retirement_contributions)  # type: ignore
+        pie_sizes.append(retirement_contributions)
 
     # add other expenses
     for expense_name, expense in user.accumulation_phase_expenses.items():
@@ -96,7 +97,7 @@ def generate_income_distribution_graph(user: Person, ax: Axes):
     def autopct_format(values):
         def percent_and_dollar_value(pct):
             total = sum(values)
-            val = pct / 100 * total
+            val = Decimal(str(pct)) / Decimal("100") * total
             return "{:.2f}% (${:.2f})".format(pct, val)
 
         return percent_and_dollar_value
@@ -104,13 +105,13 @@ def generate_income_distribution_graph(user: Person, ax: Axes):
     # calculate post tax income  without 401k/hsa deductions
     no_deduction_user = copy.copy(user)
     no_deduction_user.accounts = dict()
-    no_deduction_user.income_tax_deductions = 0
+    no_deduction_user.income_tax_deductions = Decimal("0")
     retirement_deductions_excess = calculate_annual_income_tax(
         no_deduction_user
     ) - calculate_annual_income_tax(user)
 
     ax.pie(
-        pie_sizes,
+        [float(size) for size in pie_sizes],
         labels=pie_labels,
         autopct=autopct_format(pie_sizes),
         explode=[0.02 for _ in range(len(pie_sizes))],
@@ -123,7 +124,7 @@ def generate_income_distribution_graph(user: Person, ax: Axes):
         fontstyle="italic",
     )
 
-    pie_sizes_map = {name: size for (name, size) in zip(pie_labels, pie_sizes)}
+    pie_sizes_map = {name: float(size) for (name, size) in zip(pie_labels, pie_sizes)}
     logger.info(f"Pie Sizes: {json.dumps(pie_sizes_map, indent=4)}")
 
 

--- a/tests/test_retirement.py
+++ b/tests/test_retirement.py
@@ -13,6 +13,7 @@ so that any refactor that changes the math will be detected.
 """
 
 import math
+from decimal import Decimal
 import pytest
 
 from calculate.retirement import (
@@ -142,7 +143,7 @@ class TestCalculatePreTaxIncome:
         user = Person(pre_tax_income=100_000, state_of_residence=State.TEXAS)
         GlobalParameters.configure(2024, user)
 
-    def _post_tax(self, pre_tax: float) -> float:
+    def _post_tax(self, pre_tax: Decimal) -> Decimal:
         return pre_tax - calculate_annual_income_tax(
             Person(pre_tax_income=pre_tax, state_of_residence=State.TEXAS)
         )
@@ -524,7 +525,7 @@ class TestSimulateRetirement:
         )
         GlobalParameters.configure(2024, user)
         # Override inflation AFTER configure so it is not reset
-        GlobalParameters.inflation_rate = 0.0
+        GlobalParameters.inflation_rate = Decimal("0.0")
         try:
             account = Account(
                 owner=user,
@@ -536,14 +537,14 @@ class TestSimulateRetirement:
             )
             labels = []
             values = []
-            _simulate_retirement(account, 120_000, labels, values)
+            _simulate_retirement(account, Decimal("120000"), labels, values)
             # After 1 year (12 months) the balance should be 120,000 - 12,000 = 108,000
             assert math.isclose(
                 values[0], 108_000.0, abs_tol=0.01
             ), f"Expected 108000.00 after year 1, got {values[0]:.2f}"
         finally:
             # Restore a sensible inflation rate for subsequent tests
-            GlobalParameters.inflation_rate = 0.03
+            GlobalParameters.inflation_rate = Decimal("0.03")
 
 
 # ===========================================================================

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -258,6 +258,8 @@ class TestMedicareTax:
         surtax = 50,000  * 0.09   = 4,500.00
         total  = 8,125.00
         """
+        from decimal import Decimal
+
         income = 250_000
         user = Person(
             pre_tax_income=income,
@@ -267,11 +269,13 @@ class TestMedicareTax:
         _setup(user)
         result = calculate_annual_medicare_tax(user)
         # surtax rate is 0.09 (9%) as defined in config/tax.json MedicareHighEarnerTax
-        base = income * 0.0145
-        surtax = (income - 200_000) * GlobalParameters.medicare_high_earner_tax
+        base = Decimal(str(income)) * Decimal("0.0145")
+        surtax = (
+            Decimal(str(income)) - Decimal("200000")
+        ) * GlobalParameters.medicare_high_earner_tax
         expected = base + surtax
         assert math.isclose(
-            result, expected, abs_tol=0.01
+            float(result), float(expected), abs_tol=0.01
         ), f"Expected {expected:.2f}, got {result}"
 
     def test_no_surtax_below_threshold_individual(self):

--- a/utils/globals.py
+++ b/utils/globals.py
@@ -1,5 +1,7 @@
 import json
 import logging
+from decimal import Decimal
+from typing import Optional, Union
 
 from utils.parameters import Person, State
 
@@ -7,37 +9,39 @@ logger = logging.getLogger(__name__)
 
 
 class GlobalParameters:
-    year: str | None = None
-    inflation_rate: float = 0.03
+    year: Optional[str] = None
+    inflation_rate: Decimal = Decimal("0.03")
 
     # federal tax brackets (percentage, floor/bottom value of bracket)
-    fed_individual_tax_brackets: list[tuple[float, int]] = []
-    fed_joint_tax_brackets: list[tuple[float, int]] = []
-    fed_standard_tax_deduction: int = 0
-    fed_joint_tax_deduction: int = 0
+    fed_individual_tax_brackets: list[tuple[Decimal, Decimal]] = []
+    fed_joint_tax_brackets: list[tuple[Decimal, Decimal]] = []
+    fed_standard_tax_deduction: Decimal = Decimal("0")
+    fed_joint_tax_deduction: Decimal = Decimal("0")
 
     # state tax brackets
-    state_individual_tax_brackets: list[tuple[float, int]] = []
-    state_joint_tax_brackets: list[tuple[float, int]] = []
-    state_standard_tax_deduction: int = 0
-    state_joint_tax_deduction: int = 0
+    state_individual_tax_brackets: list[tuple[Decimal, Decimal]] = []
+    state_joint_tax_brackets: list[tuple[Decimal, Decimal]] = []
+    state_standard_tax_deduction: Decimal = Decimal("0")
+    state_joint_tax_deduction: Decimal = Decimal("0")
 
-    social_security_max_taxable: int = 0
-    social_security_tax_percent: float = 0.0
+    social_security_max_taxable: Decimal = Decimal("0")
+    social_security_tax_percent: Decimal = Decimal("0")
 
-    medicare_high_earner_tax: float = 0.0
-    medicare_high_earner_salary_individual: int = 0
-    medicare_high_earner_salary_joint: int = 0
-    medicare_tax_percent: float = 0.0  # different if you are self-employed
+    medicare_high_earner_tax: Decimal = Decimal("0")
+    medicare_high_earner_salary_individual: Decimal = Decimal("0")
+    medicare_high_earner_salary_joint: Decimal = Decimal("0")
+    medicare_tax_percent: Decimal = Decimal("0")  # different if you are self-employed
 
     @classmethod
-    def configure(cls, year: int, user: Person, inflation_rate=0.03) -> None:
-        GlobalParameters.inflation_rate = inflation_rate
+    def configure(
+        cls, year: int, user: Person, inflation_rate: Union[Decimal, float, int] = 0.03
+    ) -> None:
+        GlobalParameters.inflation_rate = Decimal(str(inflation_rate))
         year_str = str(year)
         GlobalParameters.year = year_str
 
         with open("config/tax.json") as tax_json:
-            tax_dict = json.load(tax_json)[year_str]
+            tax_dict = json.load(tax_json, parse_float=Decimal)[year_str]
 
             GlobalParameters._parse_federal_tax(tax_dict["FederalTax"])
             GlobalParameters._parse_state_tax(tax_dict["StateTax"], user)
@@ -54,14 +58,16 @@ class GlobalParameters:
         GlobalParameters.fed_joint_tax_brackets = GlobalParameters._parse_tax_bracket(
             federal_tax_joint
         )
-        GlobalParameters.fed_standard_tax_deduction = federal_tax[
-            "StandardTaxDeduction"
-        ]
-        GlobalParameters.fed_joint_tax_deduction = federal_tax["JointTaxDeduction"]
+        GlobalParameters.fed_standard_tax_deduction = Decimal(
+            str(federal_tax["StandardTaxDeduction"])
+        )
+        GlobalParameters.fed_joint_tax_deduction = Decimal(
+            str(federal_tax["JointTaxDeduction"])
+        )
 
     @classmethod
     def _parse_state_tax(cls, state_tax, user: Person):
-        if user.state_of_residence == State.TEXAS:
+        if user.state_of_residence == State.TEXAS or user.state_of_residence is None:
             return
 
         state_tax = state_tax[user.state_of_residence]
@@ -74,30 +80,40 @@ class GlobalParameters:
         GlobalParameters.state_joint_tax_brackets = GlobalParameters._parse_tax_bracket(
             state_tax_joint
         )
-        GlobalParameters.state_standard_tax_deduction = state_tax[
-            "StandardTaxDeduction"
-        ]
-        GlobalParameters.state_joint_tax_deduction = state_tax["JointTaxDeduction"]
+        GlobalParameters.state_standard_tax_deduction = Decimal(
+            str(state_tax["StandardTaxDeduction"])
+        )
+        GlobalParameters.state_joint_tax_deduction = Decimal(
+            str(state_tax["JointTaxDeduction"])
+        )
 
     @classmethod
     def _parse_fica_tax(cls, fica_tax):
-        GlobalParameters.social_security_max_taxable = fica_tax[
-            "SocialSecurityMaxTaxable"
-        ]
-        GlobalParameters.social_security_tax_percent = fica_tax[
-            "SocialSecurityTaxPercent"
-        ]
-        GlobalParameters.medicare_high_earner_tax = fica_tax["MedicareHighEarnerTax"]
-        GlobalParameters.medicare_high_earner_salary_individual = fica_tax[
-            "MedicareHighEarnerSalaryIndividual"
-        ]
-        GlobalParameters.medicare_high_earner_salary_joint = fica_tax[
-            "MedicareHighEarnerSalaryJoint"
-        ]
-        GlobalParameters.medicare_tax_percent = fica_tax["MedicareTaxPercent"]
+        GlobalParameters.social_security_max_taxable = Decimal(
+            str(fica_tax["SocialSecurityMaxTaxable"])
+        )
+        GlobalParameters.social_security_tax_percent = Decimal(
+            str(fica_tax["SocialSecurityTaxPercent"])
+        )
+        GlobalParameters.medicare_high_earner_tax = Decimal(
+            str(fica_tax["MedicareHighEarnerTax"])
+        )
+        GlobalParameters.medicare_high_earner_salary_individual = Decimal(
+            str(fica_tax["MedicareHighEarnerSalaryIndividual"])
+        )
+        GlobalParameters.medicare_high_earner_salary_joint = Decimal(
+            str(fica_tax["MedicareHighEarnerSalaryJoint"])
+        )
+        GlobalParameters.medicare_tax_percent = Decimal(
+            str(fica_tax["MedicareTaxPercent"])
+        )
 
     @classmethod
-    def _parse_tax_bracket(cls, individual_or_joint_bracket: dict) -> list[tuple]:
+    def _parse_tax_bracket(
+        cls, individual_or_joint_bracket: dict
+    ) -> list[tuple[Decimal, Decimal]]:
         lower_bounds = individual_or_joint_bracket["LowerBounds"]
         percents = individual_or_joint_bracket["Percents"]
-        return list(zip(percents, lower_bounds))
+        return [
+            (Decimal(str(p)), Decimal(str(lb))) for p, lb in zip(percents, lower_bounds)
+        ]

--- a/utils/parameters.py
+++ b/utils/parameters.py
@@ -1,39 +1,50 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Union
+from decimal import Decimal
 from utils.enums import Filing, Frequency, MonthlyCompoundType, AccountType, State
+
+
+def to_decimal(val: Optional[Union[Decimal, float, int, str]]) -> Decimal:
+    if val is None:
+        return Decimal("0")
+    if isinstance(val, Decimal):
+        return val
+    return Decimal(str(val))
 
 
 class Account:
     def __init__(
         self,
         owner: Person,
-        initial_savings: int = 0,
-        regular_investment_dollar: int = 1666,
+        initial_savings: Union[Decimal, float, int] = 0,
+        regular_investment_dollar: Union[Decimal, float, int] = 1666,
         regular_investment_frequency: Frequency = Frequency.MONTHLY,
-        annual_investment_increase: float = 0.0,
-        annual_investment_return: float = 0.07,
-        annual_retirement_return: float = 0.05,
-        annual_retirement_post_tax_expense: int = 72_000,
+        annual_investment_increase: Union[Decimal, float, int] = 0.0,
+        annual_investment_return: Union[Decimal, float, int] = 0.07,
+        annual_retirement_return: Union[Decimal, float, int] = 0.05,
+        annual_retirement_post_tax_expense: Union[Decimal, float, int] = 72_000,
         compound_frequency: Frequency = Frequency.MONTHLY,
         compound_type: MonthlyCompoundType = MonthlyCompoundType.ROOT,
         account_type: AccountType = AccountType.GENERIC,
     ) -> None:
 
         self.owner: Person = owner
-        self.initial_savings: int = initial_savings
-        self.regular_investment_dollar: int = regular_investment_dollar
+        self.initial_savings: Decimal = to_decimal(initial_savings)
+        self.regular_investment_dollar: Decimal = to_decimal(regular_investment_dollar)
         self.regular_investment_frequency: Frequency = regular_investment_frequency
-        self.annual_investment_increase: float = (
+        self.annual_investment_increase: Decimal = to_decimal(
             annual_investment_increase  # percentage, how much you will contribute more next year
         )
 
-        self.annual_investment_return: float = annual_investment_return
-        self.annual_retirement_return = annual_retirement_return
-        self.annual_retirement_post_tax_expense = annual_retirement_post_tax_expense
+        self.annual_investment_return: Decimal = to_decimal(annual_investment_return)
+        self.annual_retirement_return: Decimal = to_decimal(annual_retirement_return)
+        self.annual_retirement_post_tax_expense: Decimal = to_decimal(
+            annual_retirement_post_tax_expense
+        )
         self.compound_frequency: Frequency = compound_frequency
         self.compound_type: MonthlyCompoundType = compound_type
-        self.account_type = account_type
+        self.account_type: AccountType = account_type
 
 
 class Person:
@@ -42,25 +53,31 @@ class Person:
         current_age: int = 22,
         retirement_age: int = 65,
         lifespan: int = 120,
-        pre_tax_income: float = 115_000,  # annual value
-        additional_income_tax_deductions: int = 0,  # subtracted from taxable income (income tax)
-        accumulation_phase_expenses: Optional[dict[str, int]] = None,  # annual values
+        pre_tax_income: Union[Decimal, float, int] = 115_000,  # annual value
+        additional_income_tax_deductions: Union[
+            Decimal, float, int
+        ] = 0,  # subtracted from taxable income (income tax)
+        accumulation_phase_expenses: Optional[
+            dict[str, Decimal]
+        ] = None,  # annual values
         state_of_residence: Optional[State] = None,
         filing: Filing = Filing.INDIVIDUAL,
     ) -> None:
 
         self.current_age: int = current_age
         self.retirement_age: int = retirement_age
-        self.lifespan = lifespan
-        self.pre_tax_income = pre_tax_income
-        self.income_tax_deductions = additional_income_tax_deductions
-        self.accumulation_phase_expenses = (
+        self.lifespan: int = lifespan
+        self.pre_tax_income: Decimal = to_decimal(pre_tax_income)
+        self.income_tax_deductions: Decimal = to_decimal(
+            additional_income_tax_deductions
+        )
+        self.accumulation_phase_expenses: dict[str, Decimal] = (
             dict()
             if accumulation_phase_expenses is None
-            else accumulation_phase_expenses
+            else {k: to_decimal(v) for k, v in accumulation_phase_expenses.items()}
         )
-        self.state_of_residence = state_of_residence
-        self.filing = filing
+        self.state_of_residence: Optional[State] = state_of_residence
+        self.filing: Filing = filing
         self.accounts: dict[str, Account] = dict()
 
     def add_account(self, account: Account, account_name: Optional[str] = None) -> None:
@@ -95,19 +112,22 @@ class Person:
         for account_name, account in accounts.items():
             self.add_account(account, account_name)
 
-    def add_accumulation_expense(self, name: str, expense: int, frequency: Frequency):
+    def add_accumulation_expense(
+        self, name: str, expense: Union[Decimal, float, int], frequency: Frequency
+    ) -> None:
+        expense_decimal = to_decimal(expense)
         if frequency == Frequency.MONTHLY:
-            self.accumulation_phase_expenses[name] = expense * 12
+            self.accumulation_phase_expenses[name] = expense_decimal * 12
         elif frequency == Frequency.ANNUALLY:
-            self.accumulation_phase_expenses[name] = expense
+            self.accumulation_phase_expenses[name] = expense_decimal
 
-    def get_reduced_income(self) -> float:
+    def get_reduced_income(self) -> Decimal:
         """returns income after subtracting 401(k) and HSA deductions"""
         return self.pre_tax_income - self.income_tax_deductions
 
-    def get_fica_taxable_income(self) -> float:
+    def get_fica_taxable_income(self) -> Decimal:
         """returns income that is subject to FICA (medicare/social security taxes)"""
-        total_hsa_contribution = 0
+        total_hsa_contribution = to_decimal(0)
         for _, account in self.accounts.items():
             if account.account_type == AccountType.HSA:
                 if account.regular_investment_frequency == Frequency.ANNUALLY:

--- a/utils/parse_parameters.py
+++ b/utils/parse_parameters.py
@@ -1,4 +1,5 @@
 import json
+from decimal import Decimal
 from utils.parameters import Account, Person
 from utils.globals import GlobalParameters
 
@@ -6,7 +7,7 @@ from utils.globals import GlobalParameters
 def parse_parameters() -> Person:
     user = None
     with open("config/parameters.json") as parameters_json:
-        parameter_dict = json.load(parameters_json)
+        parameter_dict = json.load(parameters_json, parse_float=Decimal)
 
     current_year = parameter_dict["CurrentYear"]
     current_year_parameters = parameter_dict[str(current_year)]


### PR DESCRIPTION
This pull request refactors the calculations in `whenCanIRetire` to use Python's built-in `decimal.Decimal` class instead of binary floating-point numbers (`float`).

### Changes
1. **Parameters & Inputs**:
   - `Person` and `Account` constructors now wrap input numbers (incomes, returns, expenses, rates) in a safe `to_decimal` helper, converting them internally to `Decimal` objects.
   - Updates `parse_parameters.py` and `globals.py` JSON loading to use `parse_float=Decimal` in `json.load`.

2. **Calculation Core**:
   - Compounding, inflation, and tax functions modified to use `Decimal` arithmetic.
   - Replaced floating-point math functions (`math.pow`, `math.inf`) with `Decimal` operations (`**`, `Decimal('Infinity')`).

3. **Entry Point & Visuals**:
   - `main.py` casts the lists of savings values and pie chart sizes to `float` only at the matplotlib boundary to maintain visualization compatibility.

4. **Testing Suite**:
   - Updated fixtures and assertions to support strict `Decimal` results. All 76 tests successfully pass.