### PR TITLE
Fix progressive tax bracket math and config data

### DIFF
--- a/config/tax.json
+++ b/config/tax.json
@@ -5,12 +5,12 @@
             "Individual": {
                 "LowerBounds": [
                     0,
-                    11601,
-                    47151,
-                    100526,
-                    191951,
-                    243726,
-                    609351
+                    11600,
+                    47150,
+                    100525,
+                    191950,
+                    243725,
+                    609350
                 ],
                 "Percents": [
                     0.10,
@@ -25,12 +25,12 @@
             "Joint": {
                 "LowerBounds": [
                     0,
-                    22001,
-                    89451,
-                    190751,
-                    364201,
-                    462501,
-                    693751
+                    22000,
+                    89450,
+                    190750,
+                    364200,
+                    462500,
+                    693750
                 ],
                 "Percents": [
                     0.10,
@@ -46,11 +46,11 @@
             "JointTaxDeduction": 27700,
             "CapitalGainsTax": {
                 "Individual": {
-                    "LowerBounds": [0, 47026, 518901],
+                    "LowerBounds": [0, 47025, 518900],
                     "Percents": [0.0, 0.15, 0.2]
                 },
                 "Joint": {
-                    "LowerBounds": [0, 94051, 583751],
+                    "LowerBounds": [0, 94050, 583750],
                     "Percents": [0.0, 0.15, 0.2]
                 }
             }
@@ -131,7 +131,8 @@
                     48475,
                     103350,
                     197300,
-                    250525
+                    250525,
+                    626350
                 ],
                 "Percents": [
                     0.10,
@@ -139,27 +140,100 @@
                     0.22,
                     0.24,
                     0.32,
-                    0.35
+                    0.35,
+                    0.37
                 ]
             },
             "Joint": {
-                "LowerBounds": [],
-                "Percents": []
+                "LowerBounds": [
+                    0,
+                    23850,
+                    96950,
+                    206700,
+                    394600,
+                    501050,
+                    751600
+                ],
+                "Percents": [
+                    0.10,
+                    0.12,
+                    0.22,
+                    0.24,
+                    0.32,
+                    0.35,
+                    0.37
+                ]
             },
-            "StandardTaxDeduction": 15000,
-            "JointTaxDeduction": 30000,
+            "StandardTaxDeduction": 15750,
+            "JointTaxDeduction": 31500,
             "CapitalGainsTax": {
                 "Individual": {
-                    "LowerBounds": [0, 48351, 533401],
+                    "LowerBounds": [0, 48350, 533400],
                     "Percents": [0.0, 0.15, 0.2]
                 },
                 "Joint": {
-                    "LowerBounds": [0, 96701, 600051],
+                    "LowerBounds": [0, 96700, 600050],
                     "Percents": [0.0, 0.15, 0.2]
                 }
             }
         },
-        "StateTax": {},
+        "StateTax": {
+            "California": {
+                "Individual": {
+                    "LowerBounds": [
+                        0,
+                        11079,
+                        26264,
+                        41452,
+                        57542,
+                        72724,
+                        371479,
+                        445771,
+                        742953
+                    ],
+                    "Percents": [
+                        0.01,
+                        0.02,
+                        0.04,
+                        0.06,
+                        0.08,
+                        0.093,
+                        0.103,
+                        0.113,
+                        0.123
+                    ]
+                },
+                "Joint": {
+                    "LowerBounds": [
+                        0,
+                        22158,
+                        52528,
+                        82904,
+                        115084,
+                        145448,
+                        742958,
+                        891542,
+                        1485906
+                    ],
+                    "Percents": [
+                        0.01,
+                        0.02,
+                        0.04,
+                        0.06,
+                        0.08,
+                        0.093,
+                        0.103,
+                        0.113,
+                        0.123
+                    ]
+                },
+                "StandardTaxDeduction": 5706,
+                "JointTaxDeduction": 11412,
+                "SDITaxPercent": 0.011,
+                "MHSTaxPercent": 0.01,
+                "MHSTaxThreshold": 1000000
+            }
+        },
         "FicaTax": {
             "SocialSecurityMaxTaxable": 176100,
             "SocialSecurityTaxPercent": 0.062,
@@ -179,7 +253,8 @@
                     50400,
                     105700,
                     201775,
-                    256225
+                    256225,
+                    640600
                 ],
                 "Percents": [
                     0.10,
@@ -187,27 +262,100 @@
                     0.22,
                     0.24,
                     0.32,
-                    0.35
+                    0.35,
+                    0.37
                 ]
             },
             "Joint": {
-                "LowerBounds": [],
-                "Percents": []
+                "LowerBounds": [
+                    0,
+                    24800,
+                    100800,
+                    211400,
+                    403550,
+                    512450,
+                    768700
+                ],
+                "Percents": [
+                    0.10,
+                    0.12,
+                    0.22,
+                    0.24,
+                    0.32,
+                    0.35,
+                    0.37
+                ]
             },
             "StandardTaxDeduction": 16100,
             "JointTaxDeduction": 32200,
             "CapitalGainsTax": {
                 "Individual": {
-                    "LowerBounds": [0, 49451, 545501],
+                    "LowerBounds": [0, 49450, 545500],
                     "Percents": [0.0, 0.15, 0.2]
                 },
                 "Joint": {
-                    "LowerBounds": [0, 98901, 613701],
+                    "LowerBounds": [0, 98900, 613700],
                     "Percents": [0.0, 0.15, 0.2]
                 }
             }
         },
-        "StateTax": {},
+        "StateTax": {
+            "California": {
+                "Individual": {
+                    "LowerBounds": [
+                        0,
+                        11079,
+                        26264,
+                        41452,
+                        57542,
+                        72724,
+                        371479,
+                        445771,
+                        742953
+                    ],
+                    "Percents": [
+                        0.01,
+                        0.02,
+                        0.04,
+                        0.06,
+                        0.08,
+                        0.093,
+                        0.103,
+                        0.113,
+                        0.123
+                    ]
+                },
+                "Joint": {
+                    "LowerBounds": [
+                        0,
+                        22158,
+                        52528,
+                        82904,
+                        115084,
+                        145448,
+                        742958,
+                        891542,
+                        1485906
+                    ],
+                    "Percents": [
+                        0.01,
+                        0.02,
+                        0.04,
+                        0.06,
+                        0.08,
+                        0.093,
+                        0.103,
+                        0.113,
+                        0.123
+                    ]
+                },
+                "StandardTaxDeduction": 5706,
+                "JointTaxDeduction": 11412,
+                "SDITaxPercent": 0.011,
+                "MHSTaxPercent": 0.01,
+                "MHSTaxThreshold": 1000000
+            }
+        },
         "FicaTax": {
             "SocialSecurityMaxTaxable": 184500,
             "SocialSecurityTaxPercent": 0.062,

--- a/tests/test_retirement.py
+++ b/tests/test_retirement.py
@@ -615,9 +615,9 @@ class TestSimulateAccount:
         user_2025 = Person(filing=Filing.INDIVIDUAL, state_of_residence=State.TEXAS)
         account_2025 = Account(owner=user_2025, account_type=AccountType.GENERIC)
 
-        # Under 2025 Single: 0% up to 48,350. Standard deduction is 15,000.
-        # Taxable gain = 60,000 - 15,000 = 45,000.
-        # Since 45,000 <= 48,350, it is all taxed at 0%. Total tax = 0.
+        # Under 2025 Single: 0% up to 48,350. Standard deduction is 15,750.
+        # Taxable gain = 60,000 - 15,750 = 44,250.
+        # Since 44,250 <= 48,350, it is all taxed at 0%. Total tax = 0.
         from calculate.retirement import calculate_retirement_withdrawal_tax
 
         tax = calculate_retirement_withdrawal_tax(
@@ -626,14 +626,14 @@ class TestSimulateAccount:
         assert tax == Decimal("0")
 
         # If gain is 100,000:
-        # Taxable gain = 100,000 - 15,000 = 85,000.
+        # Taxable gain = 100,000 - 15,750 = 84,250.
         # First 48,350 taxed at 0% (0 tax).
-        # Next 36,650 taxed at 15% (tax = (85000 - 48351) * 0.15 = 5497.35).
-        # Total tax = 5,497.35.
+        # Next 35,900 taxed at 15% (tax = 35900 * 0.15 = 5385.00).
+        # Total tax = 5,385.00.
         tax = calculate_retirement_withdrawal_tax(
             Decimal("100000"), account_2025, config_2025, is_capital_gains=True
         )
-        assert tax == Decimal("5497.35")
+        assert tax == Decimal("5385.00")
 
     def test_state_capital_gains_tax_calculators(self):
         """Verify California (progressive ordinary, no SDI, includes MHS) and Texas (0%) state capital gains tax calculators."""
@@ -652,16 +652,16 @@ class TestSimulateAccount:
         # California
         # Using 2024 config since CA tax brackets are configured for 2024.
         # Standard deduction = 5,363. Taxable gain = 20,000 - 5,363 = 14,637.
-        # First 10,412 taxed at 1% = 104.11 (due to floor/ceiling -1 gap).
+        # First 10,412 taxed at 1% = 104.12.
         # Next 4,225 taxed at 2% = 84.50.
-        # Total CA tax = 188.61.
+        # Total CA tax = 188.62.
         config_2024 = _make_config(year=2024)
         user_ca = Person(state_of_residence=State.CALIFORNIA, filing=Filing.INDIVIDUAL)
         calculator_ca = get_state_capital_gains_calculator(State.CALIFORNIA)
         ca_tax = calculator_ca.calculate_capital_gains_tax(
             Decimal("20000"), user_ca, config_2024
         )
-        assert ca_tax == Decimal("188.61")
+        assert ca_tax == Decimal("188.62")
 
     def test_get_state_capital_gains_calculator_warning(self, caplog):
         """Verify that requesting a state capital gains calculator for an unimplemented state logs a warning and falls back to ordinary state tax calculation."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -64,6 +64,7 @@ def test_missing_state_tax_raises_value_error(tax_data):
     from utils.enums import Filing, State
     from utils.globals import GlobalParameters
     from decimal import Decimal
+    import copy
 
     user = Person(
         current_age=30,
@@ -73,10 +74,16 @@ def test_missing_state_tax_raises_value_error(tax_data):
         state_of_residence=State.CALIFORNIA,
         filing=Filing.INDIVIDUAL,
     )
+
+    # Create a copy and remove California from StateTax to simulate missing state tax configuration
+    yearly_tax_copy = copy.deepcopy(tax_data.root["2026"])
+    if State.CALIFORNIA in yearly_tax_copy.StateTax:
+        del yearly_tax_copy.StateTax[State.CALIFORNIA]
+
     config_2026 = GlobalParameters(
         year=2026,
         inflation_rate=Decimal("0.03"),
-        yearly_tax=tax_data.root["2026"],
+        yearly_tax=yearly_tax_copy,
     )
 
     with pytest.raises(ValueError, match="State tax brackets configuration is missing"):

--- a/utils/globals.py
+++ b/utils/globals.py
@@ -17,16 +17,13 @@ def calculate_progressive_tax(
     for i in range(len(brackets)):
         tax_percent, floor_value = brackets[i]
         ceiling_value = (
-            brackets[i + 1][1] - Decimal("1")
-            if i + 1 < len(brackets)
-            else Decimal("Infinity")
+            brackets[i + 1][1] if i + 1 < len(brackets) else Decimal("Infinity")
         )
-        if taxable_income > ceiling_value:
-            taxes_owed += (ceiling_value - floor_value) * tax_percent
-        elif taxable_income <= floor_value:
-            break
+        if taxable_income > floor_value:
+            taxed_amount = min(taxable_income, ceiling_value) - floor_value
+            taxes_owed += taxed_amount * tax_percent
         else:
-            taxes_owed += (taxable_income - floor_value) * tax_percent
+            break
     return taxes_owed
 
 


### PR DESCRIPTION
This PR fixes the progressive tax bracket math and config data:
1. Refactored `calculate_progressive_tax` in `utils/globals.py` to be continuous and mathematically correct, removing the incorrect `$1` subtraction/gaps.
2. Standardized lower bounds for 2024 federal tax brackets in `config/tax.json` to align with the continuous calculations.
3. Fixed missing 37% federal tax brackets and empty joint brackets for 2025 and 2026.
4. Corrected the 2025 federal standard deduction.
5. Populated California state tax parameters for 2025 and 2026.
6. Updated tests in `tests/test_retirement.py` and `tests/test_validation.py` to reflect correct tax values.